### PR TITLE
app-crypt/seahorse incomplete dependency

### DIFF
--- a/app-crypt/seahorse/seahorse-3.16.0.ebuild
+++ b/app-crypt/seahorse/seahorse-3.16.0.ebuild
@@ -25,7 +25,7 @@ COMMON_DEPEND="
 
 	net-misc/openssh
 	>=app-crypt/gpgme-1
-	>=app-crypt/gnupg-1.4
+	=app-crypt/gnupg-2.0
 
 	ldap? ( net-nds/openldap:= )
 	zeroconf? ( >=net-dns/avahi-0.6:= )

--- a/app-crypt/seahorse/seahorse-3.16.0.ebuild
+++ b/app-crypt/seahorse/seahorse-3.16.0.ebuild
@@ -25,7 +25,11 @@ COMMON_DEPEND="
 
 	net-misc/openssh
 	>=app-crypt/gpgme-1
-	=app-crypt/gnupg-2.0
+	|| (
+		=app-crypt/gnupg-2.0
+		=app-crypt/gnupg-1.6
+		=app-crypt/gnupg-1.4
+	)
 
 	ldap? ( net-nds/openldap:= )
 	zeroconf? ( >=net-dns/avahi-0.6:= )


### PR DESCRIPTION
Seahorse configuration phase fails if app-crypt/gnupg version is not 1.4 or 1.6 or 2.0
