### PR TITLE
Fix Seahorse dependencies

### DIFF
--- a/app-crypt/seahorse/seahorse-3.16.0.ebuild
+++ b/app-crypt/seahorse/seahorse-3.16.0.ebuild
@@ -25,7 +25,10 @@ COMMON_DEPEND="
 
 	net-misc/openssh
 	>=app-crypt/gpgme-1
-	>=app-crypt/gnupg-1.4
+	|| (
+		=app-crypt/gnupg-2.0*
+		=app-crypt/gnupg-1.4*
+	)
 
 	ldap? ( net-nds/openldap:= )
 	zeroconf? ( >=net-dns/avahi-0.6:= )


### PR DESCRIPTION
Seahorse requires specific GnuPG versions.
WRT https://git.gnome.org/browse/seahorse/tree/configure.ac
