### PR TITLE
Fix Seahorse dependencies

### DIFF
--- a/app-crypt/seahorse/seahorse-3.16.0-r1.ebuild
+++ b/app-crypt/seahorse/seahorse-3.16.0-r1.ebuild
@@ -25,8 +25,7 @@ COMMON_DEPEND="
 
 	net-misc/openssh
 	>=app-crypt/gpgme-1
-	>=app-crypt/gnupg-1.4
-
+	<app-crypt/gnupg-2.1
 	ldap? ( net-nds/openldap:= )
 	zeroconf? ( >=net-dns/avahi-0.6:= )
 "


### PR DESCRIPTION
Seahorse does not build if gnupg has been updated to the latest version
