### PR TITLE
x11-libs/gtk+: respect user cflags

### DIFF
--- a/x11-libs/gtk+/gtk+-3.20.2.ebuild
+++ b/x11-libs/gtk+/gtk+-3.20.2.ebuild
@@ -110,10 +110,6 @@ strip_builddir() {
 }
 
 src_prepare() {
-	# -O3 and company cause random crashes in applications. Bug #133469
-	replace-flags -O3 -O2
-	strip-flags
-
 	if ! use test ; then
 		# don't waste time building tests
 		strip_builddir SRC_SUBDIRS testsuite Makefile.{am,in}

--- a/x11-libs/gtk+/gtk+-9999.ebuild
+++ b/x11-libs/gtk+/gtk+-9999.ebuild
@@ -128,10 +128,6 @@ strip_builddir() {
 }
 
 src_prepare() {
-	# -O3 and company cause random crashes in applications. Bug #133469
-	replace-flags -O3 -O2
-	strip-flags
-
 	if ! use test ; then
 		# don't waste time building tests
 		strip_builddir SRC_SUBDIRS testsuite Makefile.am


### PR DESCRIPTION
That bug was related to very old gcc versions producing bad code. It's not reproducible anymore
