### PR TITLE
gnome-extra/evolution-data-server: remove unused runtime dependencies

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.20.2.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.20.2.ebuild
@@ -30,14 +30,12 @@ RDEPEND="
 	>=app-crypt/libsecret-0.5[crypt]
 	>=dev-db/sqlite-3.7.17:=
 	>=dev-libs/glib-2.40:2
-	>=dev-libs/json-glib-1.0.4
 	>=dev-libs/libgdata-0.10:=
 	>=dev-libs/libical-0.43:=
 	>=dev-libs/libxml2-2
 	>=dev-libs/nspr-4.4:=
 	>=dev-libs/nss-3.9:=
 	>=net-libs/libsoup-2.42:2.4
-	>=net-libs/webkit-gtk-2.4.9:3
 
 	dev-libs/icu:=
 	sys-libs/zlib:=

--- a/gnome-extra/evolution-data-server/evolution-data-server-9999.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-9999.ebuild
@@ -39,14 +39,12 @@ RDEPEND="
 	>=app-crypt/libsecret-0.5[crypt]
 	>=dev-db/sqlite-3.7.17:=
 	>=dev-libs/glib-2.40:2
-	>=dev-libs/json-glib-1.0.4
 	>=dev-libs/libgdata-0.10:=
 	>=dev-libs/libical-0.43:=
 	>=dev-libs/libxml2-2
 	>=dev-libs/nspr-4.4:=
 	>=dev-libs/nss-3.9:=
 	>=net-libs/libsoup-2.42:2.4
-	>=net-libs/webkit-gtk-2.4.9:3
 
 	dev-libs/icu:=
 	sys-libs/zlib:=


### PR DESCRIPTION
webkit-gtk is already pulled in when the google useflag is set, there's no need to have it always (it's a very big dependency).
Tested on my system with

> :gnome-extra/evolution-data-server-3.20.2::gnome was built with the following:
> USE="berkdb gtk introspection ipv6 ldap vala -weather -api-doc-extras -gnome-online-accounts -google -kerberos -test" ABI_X86="64"

Not sure if it's needed when the weather useflag is set.
gnome-online-accounts already pulls it in
